### PR TITLE
[k8s attacks] add required team support

### DIFF
--- a/k8s_attacks.go
+++ b/k8s_attacks.go
@@ -74,8 +74,8 @@ type KubernetesAttack struct {
 	Attack     AttackDefinition `json:"attack"`
 }
 
-func (c *Client) ListKubernetesAttacks() (*ListKubernetesAttacksResponse, error) {
-	resp, err := c.get("/kubernetes/attacks?source=Adhoc")
+func (c *Client) ListKubernetesAttacks(team_id string) (*ListKubernetesAttacksResponse, error) {
+	resp, err := c.get("/kubernetes/attacks?source=Adhoc&teamId=" + team_id)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
all API requests (now that keys are global) required passing a `teamId`.

this adds very simple support for it.  it'll still error if the URL is invalid and teamId isn't passed.